### PR TITLE
Add sequence diagram describing data flow.

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,47 @@
+```mermaid
+
+sequenceDiagram
+    %% Driver is either the CLI or server daemon of the tool responsible for calling the subsequent units
+    participant driver
+
+    %% Fetcher is the component responsible for converting a network URL into raw bytes.
+    participant fetcher
+
+    %% Parser is the component responsible for taking the raw bytes from fetcher and turning it into a structured response 
+    %% The structured response can then be given to the driver to decide what to do with it.
+    participant parser
+
+    %% Metrics is an interface responsible for receiving telemetry in a way that the reporter package can implement. 
+    %% Using their specific counters / spans / gauge, etc.
+    participant metrics
+
+    %% Reporter is the underlying specific reporting toolset collector. Ex: OpenTelemetry, Prometheus, etc.
+    participant reporter
+    
+    rect rgb(191, 223, 255)
+    note right of driver: Resolving a single URL to structured result
+    
+    driver->>fetcher: provide URI
+    fetcher->>metrics: provide request metrics
+    fetcher->>parser: provides response and stream type
+    fetcher->>metrics: provide response metrics
+    parser->>parser: produce stream type structure
+    parser->>fetcher: provide structure
+    fetcher->>driver: provide structure
+    driver->>driver: Process Document with configured rule-set
+    driver->>metrics: provide requested metrics from rule-set
+    end
+
+    
+    
+    alt is push based
+    loop Every configured period
+        reporter->>metrics: request metrics and push to backend then clear
+    end
+    else is pull based 
+    reporter->>reporter: Make endpoint available
+        opt on request
+            reporter->>metrics: request current metrics and clear
+        end
+    end
+```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,9 +18,7 @@ sequenceDiagram
     %% Reporter is the underlying specific reporting toolset collector. Ex: OpenTelemetry, Prometheus, etc.
     participant reporter
     
-    rect rgb(191, 223, 255)
     note right of driver: Resolving a single URL to structured result
-    
     driver->>fetcher: provide URI
     fetcher->>metrics: provide request metrics
     fetcher->>parser: provides response and stream type
@@ -30,9 +28,6 @@ sequenceDiagram
     fetcher->>driver: provide structure
     driver->>driver: Process Document with configured rule-set
     driver->>metrics: provide requested metrics from rule-set
-    end
-
-    
     
     alt is push based
     loop Every configured period

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,6 @@
-```mermaid
+## Data Flow
 
+```mermaid
 sequenceDiagram
     %% Driver is either the CLI or server daemon of the tool responsible for calling the subsequent units
     participant driver

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,13 @@
 ## Data Flow
 
+| Name     | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| driver   | The CLI or Daemon reponsible for calling subsequent units of work           |
+| fetcher  | Responsible for converting a network URL into raw bytes.                    |
+| parser   | Responsible for taking raw bytes and truning it into a structured response. |
+| metrics  | An interface responsible for defining the telemetry we want to support.     |
+| reporter | The underlying reporting toolset. Ex: OpenTelemetry, Prometheus.            |
+
 ```mermaid
 sequenceDiagram
     %% Driver is either the CLI or server daemon of the tool responsible for calling the subsequent units


### PR DESCRIPTION
As discussed, I took a first-pass at adding a sequence diagram oriented on data flow to describe the various components as I've processed our discussions.

View: https://github.com/video-dev/streamlyser/blob/add-data-flow-design/DESIGN.md

I oriented the data flow into complete tasks versus streamable APIs for a few reasons.
- it lends itself to being individual units of work in a clustered use-case
- DASH requires complete document parsing
- HLS streaming reads matters for performance and TTFB for video, but we're doing availability, and performance measurement of the backend, which will be unlikely to be impacted if we fetch the Main playlist and Variant playlist a few milliseconds later than if we did it completely in a stream.

I attempted to describe the components in comments at the top as participants, and why I saw it worthwhile in separating `metrics` from `reporter`, which may simply end up represented as an interface in the real code, but was worthwhile to make the distinction so that multiple backends for reporting could be supported.

In the process of doing this, a few things have jumped out at me.
- fetching protocol support, we should stick with HTTP/S as we intend to measure performance, no reason to add S3 / Akamai specific drivers!
- some reporters are push based, and others are pull based, I structured this as the tool itself would host the HTTP endpoint.